### PR TITLE
Fix supervisorctl's serverurl for inet http server

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -23,7 +23,7 @@ username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 
 [supervisorctl]
-serverurl = http://localhost:{{ supervisor_inet_http_server_port }}
+serverurl = {{ supervisor_inet_http_server_port }}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}


### PR DESCRIPTION
`supervisor_inet_http_server_enable: true` and default `supervisor_inet_http_server_port` value resulted in
```
[supervisorctl]
serverurl = http://localhost:*:9001
```
and caused `supervisorctl` to crash with the following message:
```
error: <class 'socket.gaierror'>, [Errno -2] Name or service not known: file: /usr/lib64/python2.7/socket.py line: 553
```

Also there was no way to make `supervisorctl` listen on hosts other than `localhost`.