### PR TITLE
Fix config pidfile

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -2,6 +2,7 @@
 nodaemon = {{ supervisor_nodaemon }}
 childlogdir = {{ supervisor_log_dir }}
 user = {{ supervisor_user }}
+pidfile=/var/run/supervisord.pid
 
 {% if supervisor_unix_http_server_enable %}
 [unix_http_server]


### PR DESCRIPTION
There must be correct pidfile setting in supervisord.conf to make it
compatible with init scripts and gain control of supervisor daemon;