### PR TITLE
Resolves configuration being invalid in some cases.

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -28,6 +28,10 @@ username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}
 
+{%- if not supervisor_unix_http_server_enable and not supervisor_inet_http_server_enable %}
+[supervisorctl]
+{% endif %}
+
 [include]
 files = {{ supervisor_config_path }}/conf.d/*.conf
 

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -23,7 +23,7 @@ username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 
 [supervisorctl]
-serverurl = http://localhost:{{ supervisor_inet_http_server_port }}
+serverurl = http://{{ supervisor_inet_http_server_port }}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}


### PR DESCRIPTION
Resolves #12 

-----

I found that the error happens with python cannot run getaddrinfo() or getnameinfo(), thus it shows that error.

The host becomes incorrect because the conf will generate the `serverurl` as  `http://localhost:127.0.0.1:9001`

Resolves #14 

------

When both `supervisor_unix_http_server_enable` and `supervisor_inet_http_server_enable` is not set then the configuraiton generated does not have `[supervisorctl]` section.