### PR TITLE
 Making password protection on endpoints and supervisorctl optional (#17) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ The location where Supervisor logs will be stored.
 
 The user under which `supervisord` will be run, and the password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
 
+    supervisor_supervisorctl_password_protect: true
+    supervisor_unix_http_server_password_protect: true
+    supervisor_inet_http_server_password_protect: true
+
+Password protection can be turned off for Unix HTTP, Inet HTTP and `supervisorctl` command by setting these variables to `false`.
+
     supervisor_unix_http_server_enable: true
     supervisor_unix_http_server_socket_path: /var/run/supervisor.sock
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The user under which `supervisord` will be run, and the password to be used when
     supervisor_unix_http_server_password_protect: true
     supervisor_inet_http_server_password_protect: true
 
-Password protection can be turned off for Unix HTTP, Inet HTTP and `supervisorctl` command by setting these variables to `false`.
+Password protection can be turned off for Unix HTTP and Inet HTTP by setting these variables to `false`, This would disable password protection for `supervisorctl` as well.
 
     supervisor_unix_http_server_enable: true
     supervisor_unix_http_server_socket_path: /var/run/supervisor.sock

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The location where Supervisor logs will be stored.
 
 The user under which `supervisord` will be run, and the password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
 
-    supervisor_supervisorctl_password_protect: true
     supervisor_unix_http_server_password_protect: true
     supervisor_inet_http_server_password_protect: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,8 +33,6 @@ supervisor_log_dir: /var/log/supervisor
 supervisor_user: root
 supervisor_password: 'my_secret_password'
 
-supervisor_supervisorctl_password_protect: true
-
 supervisor_unix_http_server_enable: true
 supervisor_unix_http_server_socket_path: /var/run/supervisor.sock
 supervisor_unix_http_server_password_protect: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,8 +33,12 @@ supervisor_log_dir: /var/log/supervisor
 supervisor_user: root
 supervisor_password: 'my_secret_password'
 
+supervisor_supervisorctl_password_protect: true
+
 supervisor_unix_http_server_enable: true
 supervisor_unix_http_server_socket_path: /var/run/supervisor.sock
+supervisor_unix_http_server_password_protect: true
 
 supervisor_inet_http_server_enable: false
 supervisor_inet_http_server_port: '*:9001'
+supervisor_inet_http_server_password_protect: true

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -15,7 +15,7 @@ password = {SHA}{{ supervisor_password|hash('sha1') }}
 
 [supervisorctl]
 serverurl = unix://{{ supervisor_unix_http_server_socket_path }}
-{% if supervisor_supervisorctl_password_protect %}
+{% if supervisor_unix_http_server_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}
@@ -31,7 +31,7 @@ password = {SHA}{{ supervisor_password|hash('sha1') }}
 
 [supervisorctl]
 serverurl = http://localhost:{{ supervisor_inet_http_server_port }}
-{% if supervisor_supervisorctl_password_protect %}
+{% if supervisor_inet_http_server_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -8,25 +8,33 @@ pidfile = /var/run/supervisord.pid
 [unix_http_server]
 file = {{ supervisor_unix_http_server_socket_path }}
 chown = {{ supervisor_user }}
+{% if supervisor_unix_http_server_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
+{% endif %}
 
 [supervisorctl]
 serverurl = unix://{{ supervisor_unix_http_server_socket_path }}
+{% if supervisor_supervisorctl_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
+{% endif %}
 {% endif -%}
 
 {%- if supervisor_inet_http_server_enable %}
 [inet_http_server]
 port = {{ supervisor_inet_http_server_port }}
+{% if supervisor_inet_http_server_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
+{% endif %}
 
 [supervisorctl]
 serverurl = http://localhost:{{ supervisor_inet_http_server_port }}
+{% if supervisor_supervisorctl_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
+{% endif %}
 {% endif %}
 
 [include]


### PR DESCRIPTION
Set default values to true for backward compatibility, tested with unix_http value set to false, works fine.