### PR TITLE
Moves supervisorctl bin path to variable.

### DIFF
--- a/templates/supervisord.unit.j2
+++ b/templates/supervisord.unit.j2
@@ -6,8 +6,8 @@ Description=Supervisor daemon
 [Service]
 Type=forking
 ExecStart={{ supervisor_bin_path }} -c {{ supervisor_config_path }}/supervisord.conf
-ExecStop=/usr/bin/supervisorctl $OPTIONS shutdown
-ExecReload=/usr/bin/supervisorctl $OPTIONS reload
+ExecStop={{ supervisorctl_bin_path }} $OPTIONS shutdown
+ExecReload={{ supervisorctl_bin_path }} $OPTIONS reload
 KillMode=process
 Restart=on-failure
 RestartSec=42s

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,3 @@
 ---
 supervisor_bin_path: /usr/local/bin/supervisord
+supervisorctl_bin_path: /usr/local/bin/supervisorctl

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,3 @@
 ---
 supervisor_bin_path: /usr/bin/supervisord
+supervisorctl_bin_path: /usr/bin/supervisorctl


### PR DESCRIPTION
On Debian 8 both supervisor binaries (_supervisord_ and _supervisorctl_) are being installed into **/usr/local/bin/**. But in _/etc/systemd/system/supervisord.service_ parameters _ExecStop_ and _ExecReload_ are looking for supervisorctl in **/usr/bin/**
As a result supervisord service cannot be properly stopped or restarted.