### PR TITLE
Allow to set chown's group and chmod of unix_http_server and create the group

### DIFF
--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -18,3 +18,9 @@
     mode: 0644
   when: "ansible_service_mgr == 'systemd'"
   notify: restart supervisor
+
+- name: Create the group supervisor_chown_group
+  group:
+    name: "{{ supervisor_chown_group }}"
+    system: "{{ supervisor_chown_group_system|default(omit) }}"
+  when: supervisor_chown_group is defined and supervisor_chown_group

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -7,10 +7,14 @@ pidfile = /var/run/supervisord.pid
 {% if supervisor_unix_http_server_enable %}
 [unix_http_server]
 file = {{ supervisor_unix_http_server_socket_path }}
-chown = {{ supervisor_user }}
+chown = {{ supervisor_user }}{% if supervisor_chown_group is defined and supervisor_chown_group %}:{{ supervisor_chown_group }}{% endif %}
+
 {% if supervisor_unix_http_server_password_protect %}
 username = {{ supervisor_user }}
 password = {SHA}{{ supervisor_password|hash('sha1') }}
+{% if supervisor_chmod is defined %}
+chmod = {{ supervisor_chmod }}
+{% endif %}
 {% endif %}
 
 [supervisorctl]


### PR DESCRIPTION
https://github.com/Supervisor/supervisor/issues/173#issuecomment-186128727

To avoid permission denied error when use supervisorctl,
allow to set chown's group and chmod of unix_http_server and create the group.

---

Add the optional variables.

* supervisor_chown_group: chown's group of  unix_http_server (default:omit)
* supervisor_chmod: unix_http_server's chmod (default:omit)
* supervisor_chown_group_system: whether supervisor_chown_group is a system group (default:omit)

If supervisor_chown_group is set, the group is created.