### PR TITLE
Adding a configurable sleep time for the service restart to get around sporadic failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Whether to enable the UNIX socket-based HTTP server, and the socket file to use 
 
 Whether to enable the TCP-based HTTP server, and the interface and port on which the server should listen if enabled.
 
+    supervisor_restart_sleep: 0
+    
+On some systems, when ansible runs the restart of the service, it fails because the start happens before the stop has finished running. If this happens to you, changing this value to a larger sleep time (in seconds) will avoid this issue.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,3 +40,5 @@ supervisor_unix_http_server_password_protect: true
 supervisor_inet_http_server_enable: false
 supervisor_inet_http_server_port: '*:9001'
 supervisor_inet_http_server_password_protect: true
+
+supervisor_restart_sleep: 0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart supervisor
-  service: name=supervisord state=restarted
+  service: "name=supervisord state=restarted sleep={{ supervisor_restart_sleep }}"
   when: supervisor_started


### PR DESCRIPTION
See issue #26 