### PR TITLE
Introduces a new variable to switch pip version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Whether to enable the UNIX socket-based HTTP server, and the socket file to use 
 
 Whether to enable the TCP-based HTTP server, and the interface and port on which the server should listen if enabled.
 
+
+    supervisor_pip_executable: '/usr/bin/pip'
+    
+Specific pip executable to run. Helps to succeed in the situation when the host is managed by Ansible using Python 3, but requested Supervisor version requires only Python 2.4 or later.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,3 +40,8 @@ supervisor_unix_http_server_password_protect: true
 supervisor_inet_http_server_enable: false
 supervisor_inet_http_server_port: '*:9001'
 supervisor_inet_http_server_password_protect: true
+
+# Specific pip executable to run.
+# Helps to succeed in the situation when the host is managed by Ansible using Python 3,
+# but requested Supervisor version requires only Python 2.4 or later.
+supervisor_pip_executable: '/usr/bin/pip'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,14 @@
     name: supervisor
     state: present
     version: "{{ supervisor_version }}"
+    executable: "{{ supervisor_pip_executable }}"
   when: supervisor_version != 'latest'
 
 - name: Ensure Supervisor is installed (latest version).
   pip:
     name: supervisor
     state: present
+    executable: "{{ supervisor_pip_executable }}"
   when: supervisor_version == 'latest'
 
 - name: Ensure Supervisor log dir exists.


### PR DESCRIPTION
New `supervisor_pip_executable` variable is added.
It helps to succeed in the situation when the host
is managed by Ansible using Python 3, but requested
Supervisor version requires only Python 2.4 or later.