### PR TITLE
Allow overriding the default supervisord.unit.j2 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Whether to enable the UNIX socket-based HTTP server, and the socket file to use 
 
 Whether to enable the TCP-based HTTP server, and the interface and port on which the server should listen if enabled.
 
+
+    supervisor_systemd_unit_template: supervisord.unit.j2
+
+If the default systemd unit template does not suit your needs, you can replace it with your own.  What you need to do:
+* create a `templates` directory at the same level as your playbook
+* create a `templates/mysupervisord.unit.j2` file (make sure sure it's name is different from the default template)
+* set the variable `supervisor_systemd_unit_template: mysupervisord.unit.j2`
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,3 +40,5 @@ supervisor_unix_http_server_password_protect: true
 supervisor_inet_http_server_enable: false
 supervisor_inet_http_server_port: '*:9001'
 supervisor_inet_http_server_password_protect: true
+
+supervisor_systemd_unit_template: supervisord.unit.j2

--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -11,7 +11,7 @@
 
 - name: Copy Supervisor unit file into place (for systemd systems).
   template:
-    src: supervisord.unit.j2
+    src: "{{ supervisor_systemd_unit_template }}"
     dest: /etc/systemd/system/supervisord.service
     owner: root
     group: root


### PR DESCRIPTION
This does not change the default behaviour, it just allows to specify your own supervisord unit template. Specifically, I want to use the systemd `EnvironmentFile` option in my template but there are many other useful systemd options and I don't think this role should necessarily be concerned with handling them all.