### PR TITLE
Handle item.state == absent by deleting the config file

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -28,3 +28,11 @@
   when: item.state|default('present') != 'absent'
   with_items: "{{ supervisor_programs }}"
   notify: restart supervisor
+
+- name: Ensure unwanted Supervisor program configs are absent
+  file:
+    path: "{{ supervisor_config_path }}/conf.d/{{ item.name }}.conf"
+    state: absent
+  when: item.state|default('present') == 'absent'
+  with_items: "{{ supervisor_programs }}"
+  notify: restart supervisor


### PR DESCRIPTION
Fixes: https://github.com/geerlingguy/ansible-role-supervisor/issues/33

Program configs marked as absent will be deleted.