### PR TITLE
Use supervisorctl_bin_path variable in RedHat init script.

### DIFF
--- a/templates/supervisord.init-RedHat.j2
+++ b/templates/supervisord.init-RedHat.j2
@@ -38,7 +38,7 @@ fi
 
 # Path to the supervisorctl script, server binary,
 # and short-form for messages.
-supervisorctl=/usr/bin/supervisorctl
+supervisorctl={{ supervisorctl_bin_path }}
 supervisord=${SUPERVISORD-{{ supervisor_bin_path }}}
 prog=supervisord
 pidfile=${PIDFILE-/var/run/supervisord.pid}


### PR DESCRIPTION
I noticed the supervisorctl path is still hard coded in the template. This PR puts the variable in it's place.