### PR TITLE
Changes in templates and tasks files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The path where Supervisor configuration should be stored.
       - name: 'foo'
         command: /bin/cat
         state: present
-    
+
       - name: 'apache'
         command: apache2ctl -DFOREGROUND
         state: present
@@ -56,9 +56,14 @@ Set to `true` if you need to run Supervisor in the foreground.
 The location where Supervisor logs will be stored.
 
     supervisor_user: root
-    supervisor_password: 'my_secret_password'
 
-The user under which `supervisord` will be run, and the password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
+The user under which `supervisord` will be run
+
+    supervisor_socket_user: 'centos'
+    supervisor_socket_chown: 'centos:centos'
+    supervisor_socket_password: 'my_secret_password'
+
+The user owning the socket, and their password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
 
     supervisor_unix_http_server_password_protect: true
     supervisor_inet_http_server_password_protect: true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The user under which `supervisord` will be run
 
     supervisor_socket_user: 'centos'
     supervisor_socket_chown: 'centos:centos'
-    supervisor_socket_password: 'my_secret_password'
+    supervisor_password: 'my_secret_password'
 
 The user owning the socket, and their password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+UseGalaxy.eu no longer uses this repository. We have migrated to [SystemD](https://github.com/usegalaxy-eu/ansible-galaxy-systemd) as we find it fits better with our workflow
+
+----
+
+
 # Ansible Role: Supervisor
 
 [![Build Status](https://travis-ci.org/geerlingguy/ansible-role-supervisor.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-supervisor)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -20,7 +20,7 @@
 - name: Ensure Supervisor program configs are present.
   template:
     src: program.conf.j2
-    dest: "{{ supervisor_config_path }}/conf.d/{{ item.name }}.conf"
+    dest: "{{ supervisor_config_path }}/conf.d/galaxy.conf"
     force: true
     owner: root
     group: root

--- a/templates/program.conf.j2
+++ b/templates/program.conf.j2
@@ -1,5 +1,10 @@
+{% for item in supervisor_programs %}
 [program:{{ item.name }}]
 command={{ item.command }}
 {% if item.configuration is defined %}
 {{ item.configuration }}
 {% endif %}
+{% endfor %}
+
+[group:galaxy]
+programs: {% for item in supervisor_programs %}{% if loop.last %}{{ item.name }}{% else %}{{ item.name }}, {% endif %}{% endfor %}

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -10,14 +10,14 @@ file = {{ supervisor_unix_http_server_socket_path }}
 chown = {{ supervisor_socket_chown }}
 {% if supervisor_unix_http_server_password_protect %}
 username = {{ supervisor_socket_user }}
-password = {SHA}{{ supervisor_socket_password|hash('sha1') }}
+password = {SHA}{{ supervisor_password|hash('sha1') }}
 {% endif %}
 
 [supervisorctl]
 serverurl = unix://{{ supervisor_unix_http_server_socket_path }}
 {% if supervisor_unix_http_server_password_protect %}
 username = {{ supervisor_socket_user }}
-password = {{ supervisor_socket_password }}
+password = {{ supervisor_password }}
 {% endif %}
 {% endif -%}
 

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -7,17 +7,17 @@ pidfile = /var/run/supervisord.pid
 {% if supervisor_unix_http_server_enable %}
 [unix_http_server]
 file = {{ supervisor_unix_http_server_socket_path }}
-chown = {{ supervisor_user }}
+chown = {{ supervisor_socket_chown }}
 {% if supervisor_unix_http_server_password_protect %}
-username = {{ supervisor_user }}
-password = {SHA}{{ supervisor_password|hash('sha1') }}
+username = {{ supervisor_socket_user }}
+password = {SHA}{{ supervisor_socket_password|hash('sha1') }}
 {% endif %}
 
 [supervisorctl]
 serverurl = unix://{{ supervisor_unix_http_server_socket_path }}
 {% if supervisor_unix_http_server_password_protect %}
-username = {{ supervisor_user }}
-password = {{ supervisor_password }}
+username = {{ supervisor_socket_user }}
+password = {{ supervisor_socket_password }}
 {% endif %}
 {% endif -%}
 


### PR DESCRIPTION
These changes allow to create a single configuration file for Supervisor in which all the programs listed under the 'supervisor_programs' variable will be placed (with respective settings). This is helpful e.g. if you want a configuration with multiple handlers
[group:galaxy] allows the management of all programs related to galaxy by using a single command line for supervisor
I proposed these changes by working on my matser's degree thesis, that aims to update the galaxy installation of Laniakea by using the ansible's roles made available by the Galaxy Community, so we are trying to uniform the configuration