### PR TITLE
Remove deprecated warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,9 +17,9 @@
     state: directory
     mode: 0755
 
-- include: config.yml
+- include_tasks: config.yml
 
-- include: init-setup.yml
+- include_tasks: init-setup.yml
   when: supervisor_started or supervisor_enabled
 
 - name: Ensure Supervisor is started (if configured).


### PR DESCRIPTION
## Description

Use "include_tasks" instead of "include"

This will avoid the following warning:

```
[DEPRECATION WARNING]: "include" is deprecated, use
include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```