### PR TITLE
add supervisor_conf_template variable for main config file customization

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ supervisor_enabled: true
 
 supervisor_config_path: /etc/supervisor
 
-supervisor_conf_tempate: 'supervisord.conf.j2'
+supervisor_conf_tempate: "supervisord.conf.j2"
 
 # A list of `program`s Supervisor will control. Example commented out below.
 supervisor_programs: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ supervisor_enabled: true
 
 supervisor_config_path: /etc/supervisor
 
+supervisor_conf_tempate: 'supervisord.conf.j2'
+
 # A list of `program`s Supervisor will control. Example commented out below.
 supervisor_programs: []
 # - name: 'apache'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
 
 - name: Ensure Supervisor configuration is present.
   template:
-    src: supervisord.conf.j2
+    src: "{{ supervisor_conf_template }}"
     dest: "{{ supervisor_config_path }}/supervisord.conf"
     mode: 0644
   notify: restart supervisor


### PR DESCRIPTION
### Description
Use "{{ supervisor_conf_template }}" variable instead of hardcoded template "supervisord.conf.j2" for more main config versatility.

For example, currently there is no way to add settings like:
minfds = XXXXX
chmod = XXXX
to supervisor.conf w/o role editting.

Thx!
