### PR TITLE
Redhat 9 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         include:
           - distro: rockylinux8
             playbook: converge.yml
+          - distro: rockylinux9
+            playbook: converge.yml
           - distro: ubuntu2004
             playbook: converge.yml
           - distro: debian10

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,0 +1,3 @@
+---
+supervisor_bin_path: /usr/local/bin/supervisord
+supervisorctl_bin_path: /usr/local/bin/supervisorctl


### PR DESCRIPTION
Redhat9 requires different supervisor_bin_path by default, similar to https://github.com/geerlingguy/ansible-role-supervisor/blob/master/vars/RedHat-8.yml