### PR TITLE
Allow using APT to install Supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ An Ansible Role that installs [Supervisor](http://supervisord.org/) on Linux.
 
 ## Requirements
 
-Python `pip` should be installed. If it is not already installed, you can use the `geerlingguy.pip` Ansible role to install Pip prior to running this role.
+### Using `pip`
+
+By default, Python `pip` is used to install Supervisor, it hence should be installed. If it is not already installed, you can use the `geerlingguy.pip` Ansible role to install Pip prior to running this role.
+
+### Using `apt`
+
+On distributions that support it and if Supervisor is packaged, you can use `apt` to install Supervisor by specifying, as a variable:
+
+    supervisor_apt_install: true
+
+Depending on your distribution, the binary paths (default: `/usr/bin/local/supervisor` and `/usr/bin/local/supervisorctl`) can be overwritten:
+
+    supervisor_bin_path: /usr/bin/supervisor
+    supervisorctl_bin_path: /usr/bin/supervisorctl
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ supervisor_version: ''
 supervisor_started: true
 supervisor_enabled: true
 
+supervisor_apt_install: false
+
 supervisor_config_path: /etc/supervisor
 
 # A list of `program`s Supervisor will control. Example commented out below.

--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -18,3 +18,10 @@
     mode: 0644
   when: "ansible_service_mgr == 'systemd'"
   notify: restart supervisor
+
+- name: Disable default supervisor systemd service when installing with APT.
+  systemd:
+    name: supervisor
+    state: stopped
+    enabled: false
+  when: supervisor_apt_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,18 @@
     - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"
 
-- name: Ensure Supervisor is installed.
+- name: Ensure Supervisor is installed using pip.
   pip:
     name: supervisor
     state: present
     version: "{{ supervisor_version | default(omit) }}"
+  when: not supervisor_apt_install
+
+- name: Ensure Supervisor is installed using apt.
+  pip:
+    name: "supervisor={{ supervisor_version | default('*') }}"
+    state: present
+  when: supervisor_apt_install
 
 - name: Ensure Supervisor log dir exists.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   when: not supervisor_apt_install
 
 - name: Ensure Supervisor is installed using apt.
-  pip:
+  apt:
     name: "supervisor={{ supervisor_version | default('*') }}"
     state: present
   when: supervisor_apt_install


### PR DESCRIPTION
Two main reasons to prefer using apt:

* On Debian 12, installing supervisor with pip as a global package, like this role does, is no longer permitted.
* Pip needs compilers and other dangerous packages, that should not be installed if not needed.

A variable is introduced to allow for this, by default the role behaves as it did before, i.e. uses pip.

PS: love your videos Jeff! :)