### PR TITLE
fix: externally-managed python on later ubuntu/debian installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,17 @@
     - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"
 
+- name: Ensure Pip is installed.
+  package:
+    name: "{{ pip_package }}"
+    state: present
+
+- name: Remove EXTERNALLY-MANAGED.
+  file:
+    path: /usr/lib/python3.{{ ansible_python.version.minor }}/EXTERNALLY-MANAGED
+    state: absent
+  ignore_errors: true
+
 - name: Ensure Supervisor is installed.
   pip:
     name: supervisor


### PR DESCRIPTION
Fix for #60 

Same as https://github.com/geerlingguy/ansible-role-pip/pull/69